### PR TITLE
Add Flask web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # NewsAgg
 
-NewsAgg is a simple command-line tool that aggregates the most-viewed
-articles from several Greek news sites.
+NewsAgg is a simple tool that aggregates the most-viewed
+articles from several Greek news sites. Results can be viewed from the
+command line or through a lightweight web application.
 
 ## Usage
 
@@ -19,4 +20,17 @@ python -m newsagg.cli -n 5 --version
 ```
 
 The package lives in the `newsagg/` directory and is currently at
-version `0.1.0`.
+version `0.2.0`.
+
+## Web Application
+
+Run the built-in web server to view the aggregated news in your browser:
+
+```bash
+python -m newsagg.webapp
+```
+
+Navigate to `http://localhost:5000/` to see the results. You can supply
+the query parameter `n` to control how many items per source are
+displayed.
+The server implementation can be found in `newsagg/webapp.py`.

--- a/newsagg/__init__.py
+++ b/newsagg/__init__.py
@@ -2,7 +2,7 @@
 
 import os
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 PACKAGE_PATH = os.path.dirname(os.path.abspath(__file__))
 
 from .aggregator import aggregate

--- a/newsagg/aggregator.py
+++ b/newsagg/aggregator.py
@@ -85,8 +85,10 @@ SOURCES = [
 ]
 
 
+from . import __version__
+
 _SESSION = requests.Session()
-_SESSION.headers.update({"User-Agent": "NewsAgg/0.1"})
+_SESSION.headers.update({"User-Agent": f"NewsAgg/{__version__}"})
 
 
 def get_max_pages_from_soup(soup: BeautifulSoup) -> int:

--- a/newsagg/webapp.py
+++ b/newsagg/webapp.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from flask import Flask, render_template_string, request
+
+from . import aggregate
+
+app = Flask(__name__)
+
+HTML_TEMPLATE = """
+<!doctype html>
+<html>
+<head>
+    <meta charset='utf-8'>
+    <title>NewsAgg</title>
+</head>
+<body>
+    <h1>Aggregated News</h1>
+    <ul>
+    {% for item in news %}
+        <li><a href="{{ item['link'] }}">{{ item['source'] }} - {{ item['title'] }}</a></li>
+    {% endfor %}
+    </ul>
+</body>
+</html>
+"""
+
+
+@app.route("/")
+def index() -> str:
+    """Render aggregated news as an HTML page."""
+    top = request.args.get("n", type=int, default=10)
+    news = aggregate(top)
+    return render_template_string(HTML_TEMPLATE, news=news)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- add a `webapp` module that runs a small Flask server
- expose package version 0.2.0
- update user agent header to use package version
- document the new web server in the README

## Testing
- `python -m py_compile newsagg/*.py main.py`
- `python -m newsagg.cli -n 1 --version`
- `python -m newsagg.cli -n 1` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687a1f0f6c7883229a2d2011221424b7