### PR TITLE
Add __main__ entry point and enhance version output

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,13 @@ command line or through a lightweight web application.
 
 ## Usage
 
-Run the tool using the provided script:
+Run the tool using the provided script or directly as a module:
 
 ```bash
 python main.py
+
+# or simply
+python -m newsagg -n 5
 ```
 
 You can also invoke the CLI module directly and specify the number of
@@ -20,7 +23,10 @@ python -m newsagg.cli -n 5 --version
 ```
 
 The package lives in the `newsagg/` directory and is currently at
-version `0.2.0`.
+version `0.3.0`.
+Running with `--version` will also print the path to the main
+aggregator file. The core scraping logic resides in
+`newsagg/aggregator.py`.
 
 ## Web Application
 

--- a/newsagg/__init__.py
+++ b/newsagg/__init__.py
@@ -2,9 +2,9 @@
 
 import os
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 PACKAGE_PATH = os.path.dirname(os.path.abspath(__file__))
 
-from .aggregator import aggregate
+from .aggregator import aggregate, FILE_PATH as AGGREGATOR_PATH
 
-__all__ = ["aggregate", "__version__", "PACKAGE_PATH"]
+__all__ = ["aggregate", "__version__", "PACKAGE_PATH", "AGGREGATOR_PATH"]

--- a/newsagg/__main__.py
+++ b/newsagg/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/newsagg/aggregator.py
+++ b/newsagg/aggregator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import re
 from typing import List, Dict, Tuple
 from urllib.parse import urljoin
@@ -86,6 +87,8 @@ SOURCES = [
 
 
 from . import __version__
+
+FILE_PATH = os.path.abspath(__file__)
 
 _SESSION = requests.Session()
 _SESSION.headers.update({"User-Agent": f"NewsAgg/{__version__}"})

--- a/newsagg/cli.py
+++ b/newsagg/cli.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 
-from . import __version__, PACKAGE_PATH, aggregate
+from . import __version__, PACKAGE_PATH, AGGREGATOR_PATH, aggregate
 
 
 def main() -> None:
@@ -15,7 +15,10 @@ def main() -> None:
     parser.add_argument(
         "--version",
         action="version",
-        version=f"NewsAgg {__version__} ({PACKAGE_PATH})",
+        version=(
+            f"NewsAgg {__version__} "
+            f"(package: {PACKAGE_PATH}, aggregator: {AGGREGATOR_PATH})"
+        ),
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary
- expose aggregator path through `AGGREGATOR_PATH`
- show aggregator path when running CLI `--version`
- bump package version to 0.3.0
- add `__main__.py` so the package can be run with `python -m newsagg`
- update README with new usage instructions and version info

## Testing
- `python -m newsagg.cli --version`
- `python -m newsagg -n 1` *(fails: 403 Forbidden for external sites)*

------
https://chatgpt.com/codex/tasks/task_e_687a20ce62e88322a1d7c55c97ff2af8