### PR TITLE
Add blog-style dynamic webpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ python -m newsagg.cli -n 5 --version
 ```
 
 The package lives in the `newsagg/` directory and is currently at
-version `0.4.0`.
-Running with `--version` will also print the path to the main
-aggregator file. The core scraping logic resides in
-`newsagg/aggregator.py`.
+version `0.5.0`.
+Running with `--version` will also print the paths to the main
+aggregator file and the blog template used by the web server. The core
+scraping logic resides in `newsagg/aggregator.py`.
 
 ## Web Application
 
@@ -38,5 +38,6 @@ python -m newsagg.webapp
 
 Navigate to `http://localhost:5000/` to see the results. You can supply
 the query parameter `n` to control how many items per source are
-displayed.
-The server implementation can be found in `newsagg/webapp.py`.
+displayed. The page now uses a blog-style template located at
+`newsagg/templates/blog.html` for a cleaner, dynamic view of the
+headlines. The server implementation can be found in `newsagg/webapp.py`.

--- a/newsagg/__init__.py
+++ b/newsagg/__init__.py
@@ -2,9 +2,17 @@
 
 import os
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 PACKAGE_PATH = os.path.dirname(os.path.abspath(__file__))
+
+BLOG_TEMPLATE_PATH = os.path.join(PACKAGE_PATH, "templates", "blog.html")
 
 from .aggregator import aggregate, FILE_PATH as AGGREGATOR_PATH
 
-__all__ = ["aggregate", "__version__", "PACKAGE_PATH", "AGGREGATOR_PATH"]
+__all__ = [
+    "aggregate",
+    "__version__",
+    "PACKAGE_PATH",
+    "AGGREGATOR_PATH",
+    "BLOG_TEMPLATE_PATH",
+]

--- a/newsagg/cli.py
+++ b/newsagg/cli.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import argparse
 
-from . import __version__, PACKAGE_PATH, AGGREGATOR_PATH, aggregate
+from . import (
+    __version__,
+    PACKAGE_PATH,
+    AGGREGATOR_PATH,
+    BLOG_TEMPLATE_PATH,
+    aggregate,
+)
 
 
 def main() -> None:
@@ -17,7 +23,8 @@ def main() -> None:
         action="version",
         version=(
             f"NewsAgg {__version__} "
-            f"(package: {PACKAGE_PATH}, aggregator: {AGGREGATOR_PATH})"
+            f"(package: {PACKAGE_PATH}, aggregator: {AGGREGATOR_PATH}, "
+            f"template: {BLOG_TEMPLATE_PATH})"
         ),
     )
     args = parser.parse_args()

--- a/newsagg/templates/blog.html
+++ b/newsagg/templates/blog.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset='utf-8'>
+    <title>NewsAgg Blog View</title>
+    <style>
+        body { font-family: Arial, sans-serif; max-width: 800px; margin: auto; }
+        header { text-align: center; }
+        article { border-bottom: 1px solid #ccc; padding: 1em 0; }
+        h2 { margin-bottom: 0.2em; }
+        .source { color: #555; font-size: 0.9em; }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Aggregated News</h1>
+    </header>
+    {% for item in news %}
+    <article>
+        <h2><a href="{{ item['link'] }}">{{ item['title'] }}</a></h2>
+        <div class="source">{{ item['source'] }}</div>
+    </article>
+    {% endfor %}
+</body>
+</html>

--- a/newsagg/webapp.py
+++ b/newsagg/webapp.py
@@ -1,36 +1,17 @@
 from __future__ import annotations
 
-from flask import Flask, render_template_string, request
+from flask import Flask, render_template, request
 
 from . import aggregate
 
 app = Flask(__name__)
-
-HTML_TEMPLATE = """
-<!doctype html>
-<html>
-<head>
-    <meta charset='utf-8'>
-    <title>NewsAgg</title>
-</head>
-<body>
-    <h1>Aggregated News</h1>
-    <ul>
-    {% for item in news %}
-        <li><a href="{{ item['link'] }}">{{ item['source'] }} - {{ item['title'] }}</a></li>
-    {% endfor %}
-    </ul>
-</body>
-</html>
-"""
-
 
 @app.route("/")
 def index() -> str:
     """Render aggregated news as an HTML page."""
     top = request.args.get("n", type=int, default=10)
     news = aggregate(top)
-    return render_template_string(HTML_TEMPLATE, news=news)
+    return render_template("blog.html", news=news)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- provide blog.html template for a dynamic web page
- render blog template from the Flask server
- expose blog template path via package init and CLI
- bump version to 0.5.0 and update README

## Testing
- `python -m newsagg.cli --version`
- `python -m newsagg.webapp` *(fails: Development server run due to missing dependencies earlier; installed them and server starts)*


------
https://chatgpt.com/codex/tasks/task_e_687a2a3dfc24832282ad147750b69d27