### PR TITLE
Add article previews and update blog layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ python -m newsagg.cli -n 5 --version
 ```
 
 The package lives in the `newsagg/` directory and is currently at
-version `0.5.0`.
+version `0.6.0`.
 Running with `--version` will also print the paths to the main
-aggregator file and the blog template used by the web server. The core
+aggregator file and the blog template used by the web server as well as
+their individual versions. The core
 scraping logic resides in `newsagg/aggregator.py`.
 
 ## Web Application
@@ -40,4 +41,5 @@ Navigate to `http://localhost:5000/` to see the results. You can supply
 the query parameter `n` to control how many items per source are
 displayed. The page now uses a blog-style template located at
 `newsagg/templates/blog.html` for a cleaner, dynamic view of the
-headlines. The server implementation can be found in `newsagg/webapp.py`.
+headlines and includes a short preview snippet for each entry. The server
+implementation can be found in `newsagg/webapp.py`.

--- a/newsagg/__init__.py
+++ b/newsagg/__init__.py
@@ -2,17 +2,22 @@
 
 import os
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 PACKAGE_PATH = os.path.dirname(os.path.abspath(__file__))
 
 BLOG_TEMPLATE_PATH = os.path.join(PACKAGE_PATH, "templates", "blog.html")
 
-from .aggregator import aggregate, FILE_PATH as AGGREGATOR_PATH
+from .aggregator import (
+    aggregate,
+    FILE_PATH as AGGREGATOR_PATH,
+    FILE_VERSION as AGGREGATOR_VERSION,
+)
 
 __all__ = [
     "aggregate",
     "__version__",
     "PACKAGE_PATH",
     "AGGREGATOR_PATH",
+    "AGGREGATOR_VERSION",
     "BLOG_TEMPLATE_PATH",
 ]

--- a/newsagg/cli.py
+++ b/newsagg/cli.py
@@ -8,6 +8,7 @@ from . import (
     __version__,
     PACKAGE_PATH,
     AGGREGATOR_PATH,
+    AGGREGATOR_VERSION,
     BLOG_TEMPLATE_PATH,
     aggregate,
 )
@@ -23,7 +24,8 @@ def main() -> None:
         action="version",
         version=(
             f"NewsAgg {__version__} "
-            f"(package: {PACKAGE_PATH}, aggregator: {AGGREGATOR_PATH}, "
+            f"(package: {PACKAGE_PATH}, "
+            f"aggregator: {AGGREGATOR_PATH} v{AGGREGATOR_VERSION}, "
             f"template: {BLOG_TEMPLATE_PATH})"
         ),
     )
@@ -32,6 +34,8 @@ def main() -> None:
     news = aggregate(args.top)
     for idx, item in enumerate(news, start=1):
         print(f"{idx}. [{item['source']}] {item['title']} - {item['link']}")
+        if item.get("preview"):
+            print(f"    {item['preview']}")
 
 
 if __name__ == "__main__":

--- a/newsagg/templates/blog.html
+++ b/newsagg/templates/blog.html
@@ -4,11 +4,12 @@
     <meta charset='utf-8'>
     <title>NewsAgg Blog View</title>
     <style>
-        body { font-family: Arial, sans-serif; max-width: 800px; margin: auto; }
-        header { text-align: center; }
-        article { border-bottom: 1px solid #ccc; padding: 1em 0; }
+        body { font-family: Arial, sans-serif; max-width: 800px; margin: auto; background: #f9f9f9; }
+        header { text-align: center; margin: 2em 0; }
+        article { background: #fff; border: 1px solid #ccc; border-radius: 5px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); padding: 1em; margin-bottom: 1.5em; }
         h2 { margin-bottom: 0.2em; }
-        .source { color: #555; font-size: 0.9em; }
+        .source { color: #555; font-size: 0.9em; margin-bottom: 0.5em; }
+        .preview { margin-top: 0.5em; }
     </style>
 </head>
 <body>
@@ -19,6 +20,9 @@
     <article>
         <h2><a href="{{ item['link'] }}">{{ item['title'] }}</a></h2>
         <div class="source">{{ item['source'] }}</div>
+        {% if item['preview'] %}
+        <p class="preview">{{ item['preview'] }}</p>
+        {% endif %}
     </article>
     {% endfor %}
 </body>


### PR DESCRIPTION
## Summary
- enhance aggregator with preview fetching
- expose aggregator version and include in CLI output
- redesign blog template for better visuals and show article previews
- display previews in CLI output
- document new version and features

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687a2bffe6388322a693ed06a57d688a