### PR TITLE
Improve blog layout and add path/version info

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ python -m newsagg.cli -n 5 --version
 ```
 
 The package lives in the `newsagg/` directory and is currently at
-version `0.7.0`.
-Running with `--version` will also print the paths to the main
+version `0.7.1`.
+Running with `--version` will also print the paths to the CLI
+(`newsagg/cli.py`), web application (`newsagg/webapp.py`), the main
 aggregator file (`newsagg/aggregator.py`) and the blog template
 (`newsagg/templates/blog.html`) used by the web server as well as their
 individual versions. The core scraping logic resides in
@@ -43,6 +44,7 @@ Navigate to `http://localhost:5000/` to see the results. You can supply
 the query parameter `n` to control how many items per source are
 displayed. The page now uses a blog-style template located at
 `newsagg/templates/blog.html` for a cleaner, photo-friendly layout
-inspired by [Riverside.fm](https://Riverside.fm). Each entry shows a
-preview snippet and an article image when available. The server
-implementation can be found in `newsagg/webapp.py`.
+inspired by [Riverside.fm](https://Riverside.fm). The template now uses
+Bootstrap to improve the block/card styling. Each entry shows a preview
+snippet and an article image when available. The server implementation
+can be found in `newsagg/webapp.py`.

--- a/newsagg/__init__.py
+++ b/newsagg/__init__.py
@@ -2,11 +2,17 @@
 
 import os
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 PACKAGE_PATH = os.path.dirname(os.path.abspath(__file__))
 
 BLOG_TEMPLATE_PATH = os.path.join(PACKAGE_PATH, "templates", "blog.html")
-BLOG_TEMPLATE_VERSION = "1.0"
+BLOG_TEMPLATE_VERSION = "2.0"
+
+CLI_PATH = os.path.join(PACKAGE_PATH, "cli.py")
+CLI_VERSION = __version__
+
+WEBAPP_PATH = os.path.join(PACKAGE_PATH, "webapp.py")
+WEBAPP_VERSION = __version__
 
 from .aggregator import (
     aggregate,
@@ -22,4 +28,8 @@ __all__ = [
     "AGGREGATOR_VERSION",
     "BLOG_TEMPLATE_PATH",
     "BLOG_TEMPLATE_VERSION",
+    "CLI_PATH",
+    "CLI_VERSION",
+    "WEBAPP_PATH",
+    "WEBAPP_VERSION",
 ]

--- a/newsagg/cli.py
+++ b/newsagg/cli.py
@@ -11,8 +11,17 @@ from . import (
     AGGREGATOR_VERSION,
     BLOG_TEMPLATE_PATH,
     BLOG_TEMPLATE_VERSION,
+    CLI_PATH,
+    CLI_VERSION,
+    WEBAPP_PATH,
+    WEBAPP_VERSION,
     aggregate,
 )
+
+import os
+
+FILE_PATH = os.path.abspath(__file__)
+FILE_VERSION = CLI_VERSION
 
 
 def main() -> None:
@@ -26,6 +35,8 @@ def main() -> None:
         version=(
             f"NewsAgg {__version__} "
             f"(package: {PACKAGE_PATH}, "
+            f"CLI: {CLI_PATH} v{CLI_VERSION}, "
+            f"webapp: {WEBAPP_PATH} v{WEBAPP_VERSION}, "
             f"aggregator: {AGGREGATOR_PATH} v{AGGREGATOR_VERSION}, "
             f"template: {BLOG_TEMPLATE_PATH} v{BLOG_TEMPLATE_VERSION})"
         ),

--- a/newsagg/templates/blog.html
+++ b/newsagg/templates/blog.html
@@ -1,68 +1,43 @@
 <!doctype html>
-<!-- Blog Template version 1.0 | Design inspired by Riverside.fm -->
+<!-- Blog Template version 2.0 | Design inspired by Riverside.fm -->
 <html>
-<head>
-    <meta charset='utf-8'>
+  <head>
+    <meta charset="utf-8" />
     <title>NewsAgg Blog View</title>
-    <style>
-        body {
-            font-family: Arial, sans-serif;
-            max-width: 800px;
-            margin: auto;
-            background: #f9f9f9;
-            color: #333;
-        }
-        header {
-            text-align: center;
-            margin: 2em 0;
-        }
-        header p {
-            color: #666;
-        }
-        article {
-            background: #fff;
-            border: 1px solid #ccc;
-            border-radius: 5px;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-            padding: 1em;
-            margin-bottom: 1.5em;
-        }
-        h2 {
-            margin-bottom: 0.2em;
-        }
-        .source {
-            color: #555;
-            font-size: 0.9em;
-            margin-bottom: 0.5em;
-        }
-        .preview {
-            margin-top: 0.5em;
-        }
-        .thumb {
-            width: 100%;
-            max-height: 200px;
-            object-fit: cover;
-            border-radius: 4px;
-            margin-bottom: 0.5em;
-        }
-    </style>
-</head>
-<body>
-    <header>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
+      integrity="sha384-XLc+S3Eob8sY9qsK0kGxHgd6NqBJ38qJNmPR9U1FVLtZL1YI7Di5urN6byN1NsZM"
+      crossorigin="anonymous"
+    />
+  </head>
+  <body class="bg-light">
+    <div class="container my-4">
+      <header class="text-center mb-4">
         <h1>Aggregated News</h1>
-        <p>A sample blog layout taking cues from Riverside.fm's clean and photo-forward design.</p>
-    </header>
-    {% for item in news %}
-    <article>
-        <h2><a href="{{ item['link'] }}">{{ item['title'] }}</a></h2>
-        <div class="source">{{ item['source'] }}</div>
+        <p class="text-muted">
+          A sample blog layout taking cues from Riverside.fm's clean and photo-forward
+          design.
+        </p>
+      </header>
+      {% for item in news %}
+      <div class="card mb-4">
         {% if item['image'] %}
-        <img src="{{ item['image'] }}" alt="{{ item['title'] }}" class="thumb"/>
+        <img
+          src="{{ item['image'] }}"
+          alt="{{ item['title'] }}"
+          class="card-img-top"
+        />
         {% endif %}
-        {% if item['preview'] %}
-        <p class="preview">{{ item['preview'] }}</p>
-        {% endif %}
-    </article>
-    {% endfor %}
-</body>
+        <div class="card-body">
+          <h5 class="card-title"><a href="{{ item['link'] }}">{{ item['title'] }}</a></h5>
+          <div class="text-muted mb-2">{{ item['source'] }}</div>
+          {% if item['preview'] %}
+          <p class="card-text">{{ item['preview'] }}</p>
+          {% endif %}
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  </body>
 </html>

--- a/newsagg/webapp.py
+++ b/newsagg/webapp.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from flask import Flask, render_template, request
 
-from . import aggregate
+import os
+
+from . import __version__, aggregate
+
+FILE_PATH = os.path.abspath(__file__)
+FILE_VERSION = __version__
 
 app = Flask(__name__)
 


### PR DESCRIPTION
## Summary
- modernize the blog template using Bootstrap for card-based styling
- expose CLI and webapp path/version constants
- show new metadata in `--version` output
- bump package to 0.7.1 and update README accordingly

## Testing
- `python -m newsagg.cli --version`
- `python -m newsagg.cli -n 1 | head`
- `python -m newsagg.webapp` *(launched and terminated)*

------
https://chatgpt.com/codex/tasks/task_e_687a30c4f57883228e35cb10214ade87